### PR TITLE
Adding few options to run on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+hadolint

--- a/lint.sh
+++ b/lint.sh
@@ -30,5 +30,4 @@ if ! command -v hadolint >/dev/null; then
     fi
 fi
 
-set -x
 $CMD "$@"

--- a/lint.sh
+++ b/lint.sh
@@ -6,12 +6,19 @@ set -o nounset
 
 export PATH=$PATH:/usr/local/bin
 
-if ! which hadolint &>/dev/null; then
-    >&2 echo 'hadolint command not found'
-    if [ -z "$(command -v brew)" ]; then
-        exit 1
+CMD="hadolint"
+
+if ! command -v hadolint >/dev/null; then
+    if [ -n "$(command -v brew)" ]; then
+        >&2 echo "hadolint: installing using brew"
+        brew install hadolint
+    elif [ -n "$(command -v docker)" ]; then
+        >&2 echo "hadolint: running with docker"
+        CMD="docker run --rm --volume=$PWD:$PWD:ro --workdir=$PWD hadolint/hadolint hadolint"
+    else
+        >&2 echo "hadolint: command not found and don't know how to install"
     fi
-    brew install hadolint
 fi
 
-hadolint "$@"
+set -x
+$CMD "$@"

--- a/lint.sh
+++ b/lint.sh
@@ -7,11 +7,21 @@ set -o nounset
 export PATH=$PATH:/usr/local/bin
 
 CMD="hadolint"
+SCRIPT_DIR="$( cd `dirname "$0"` && pwd )"
+export PATH="$SCRIPT_DIR:$PATH"
 
 if ! command -v hadolint >/dev/null; then
     if [ -n "$(command -v brew)" ]; then
         >&2 echo "hadolint: installing using brew"
         brew install hadolint
+    elif [ -n "$(command -v curl)" ]; then
+        VERSION="v1.17.6"
+        URL="https://github.com/hadolint/hadolint/releases/download/$VERSION/hadolint-$(uname)-x86_64"
+        if ! curl -fsSL "$URL" -o "$SCRIPT_DIR/hadolint"; then
+            >&2 echo "hadolint: unable to download from $URL"
+            exit 1
+        fi
+        chmod +x "$SCRIPT_DIR/hadolint"
     elif [ -n "$(command -v docker)" ]; then
         >&2 echo "hadolint: running with docker"
         CMD="docker run --rm --volume=$PWD:$PWD:ro --workdir=$PWD hadolint/hadolint hadolint"


### PR DESCRIPTION
Instead of supporting just brew for auto-install, the system can now install from released binaries (if curl) is installed, or can also run using Docker hadolint/hadolint image.